### PR TITLE
#297488 - make vertical merge opt-out per trace table instead of hard…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -420,7 +420,7 @@ export default class Skins {
       switch (this.skinFormat) {
         case 'json':
           let traceSkin: any[] = [];
-          const { title, adoptedData, errorMessage, groupedHeader } = data;
+          const { title, adoptedData, errorMessage, groupedHeader, enableVerticalMerge = true } = data;
           if (title) {
             let traceTitle = new JSONHeaderParagraph(title.fields, styles, undefined, title.level);
             traceSkin.push(traceTitle.getJSONParagraph());
@@ -436,7 +436,7 @@ export default class Skins {
               undefined,
               false,
               groupedHeader,
-              true
+              enableVerticalMerge
             );
             traceSkin.push(tableSkin.getJSONTable());
           } else if (errorMessage !== null) {

--- a/src/test/SkinsEdgeCases.test.ts
+++ b/src/test/SkinsEdgeCases.test.ts
@@ -202,6 +202,57 @@ describe('Skins – edge cases and public API', () => {
     expect(groupedRow.Cells[0].gridSpan).toBeGreaterThan(0);
   });
 
+  test('generateTraceTable defaults to vertical merge enabled when the flag is omitted (SRS back-compat)', () => {
+    const skins = new Skins('json', 'c://template.dotx');
+
+    const buildRow = (nameValue: string) => ({
+      url: '',
+      level: 0,
+      Source: 1,
+      fields: [
+        { name: 'ID', value: 1 },
+        { name: 'Name', value: nameValue },
+      ],
+    });
+
+    const traceData = {
+      title: undefined,
+      adoptedData: [buildRow('Repeated'), buildRow('')],
+      errorMessage: null,
+    };
+
+    const result = skins.generateTraceTable(traceData as any, baseHeaderStyles as any, baseStyles as any, 0);
+    const table: any = result[0];
+
+    expect(table.Rows[2].Cells[1].vMerge).toBe('continue');
+  });
+
+  test('generateTraceTable does not merge when enableVerticalMerge is explicitly false', () => {
+    const skins = new Skins('json', 'c://template.dotx');
+
+    const buildRow = (nameValue: string) => ({
+      url: '',
+      level: 0,
+      Source: 1,
+      fields: [
+        { name: 'ID', value: 1 },
+        { name: 'Name', value: nameValue },
+      ],
+    });
+
+    const traceData = {
+      title: undefined,
+      adoptedData: [buildRow('Repeated'), buildRow('')],
+      errorMessage: null,
+      enableVerticalMerge: false,
+    };
+
+    const result = skins.generateTraceTable(traceData as any, baseHeaderStyles as any, baseStyles as any, 0);
+    const table: any = result[0];
+
+    expect(table.Rows[2].Cells[1].vMerge).toBeUndefined();
+  });
+
   test('generateTraceTable falls back to error paragraph when no adoptedData but errorMessage exists', () => {
     const skins = new Skins('json', 'c://template.dotx');
 


### PR DESCRIPTION
…coded on

generateTraceTable() forced enableVerticalMerge=true for every trace table regardless of caller. The merge heuristic (same fill color + empty cell text) only produces correct output when a caller deliberately blanks repeated source cells for grouping — which only the SRS forward-trace adapter does. Callers that never blank anything (Req<->Test query-results, linked-requirement trace) got the same heuristic applied for free, so any genuinely empty field value (e.g. a blank custom column) merged by coincidence with the row above.

Read enableVerticalMerge from the caller's data payload, defaulting to true to preserve existing SRS behavior unchanged.